### PR TITLE
Add flicker-free project carousel and hero pattern

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -248,16 +248,8 @@ section{ scroll-margin-top: 72px; }
 /* Projects carousel */
 .carousel{ position: relative; }
 .carousel-viewport{ overflow: hidden; }
-.carousel-track{ display: flex; gap: 16px; cursor: grab; user-select:none; will-change: transform; }
+.carousel-track{ display: flex; gap: 16px; cursor: grab; user-select:none; }
 .carousel-track.grabbing{ cursor: grabbing; }
-.car-arrow{
-  position:absolute; top:50%; transform: translateY(-50%); z-index:2;
-  width:38px; height:38px; border-radius:50%;
-  background: rgba(0,0,0,.45); color:#eaeaea; border:1px solid rgba(255,255,255,.1);
-  display:grid; place-items:center;
-}
-.car-arrow.left{ left: -8px; } .car-arrow.right{ right: -8px; }
-.car-arrow:hover{ background: rgba(0,0,0,.6); }
 
 .project-card {
   flex: 0 0 var(--card-w, clamp(260px, 32vw, 340px));

--- a/assets/js/carousel.js
+++ b/assets/js/carousel.js
@@ -1,100 +1,82 @@
 (() => {
   const viewport = document.querySelector('#project-carousel .carousel-viewport');
-  const track = document.querySelector('#project-carousel .carousel-track');
-  const leftBtn = document.querySelector('#project-carousel .car-arrow.left');
-  const rightBtn = document.querySelector('#project-carousel .car-arrow.right');
+  const track = viewport?.querySelector('.carousel-track');
   if (!viewport || !track) return;
 
   const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  // Fill with clones so width is plenty for seamless loop
+  // measure originals and clone until track width >= 3× viewport width
   const originals = Array.from(track.children);
-  function fillClones(){
-    let i = 0;
-    const neededWidth = viewport.clientWidth * 2.5;
-    while (track.scrollWidth < neededWidth){
-      const clone = originals[i % originals.length].cloneNode(true);
-      track.appendChild(clone);
-      i++;
-    }
-    track.querySelectorAll('img,a').forEach(el => el.setAttribute('draggable','false'));
-  }
-  fillClones();
-
-  let x = 0;                 // translateX
-  const BASE = reduce ? 0 : 45; // px/sec auto speed
-  let base = BASE;
-  let boost = 0;             // user speed delta (decays)
-  let down = false, dragging = false;
-  let lastX = 0, lastT = performance.now();
-  const THRESH = 6;          // px before "drag"
-  const MAX = 1200;          // max boost magnitude
-
-  function recycle(){
-    const slides = Array.from(track.children);
-    if (!slides.length) return;
-    const gap = parseFloat(getComputedStyle(track).gap) || 0;
-    const vpRect = viewport.getBoundingClientRect();
-    const first = slides[0], last = slides[slides.length-1];
-    if (first.getBoundingClientRect().right < vpRect.left) {
-      x += first.getBoundingClientRect().width + gap;
-      track.appendChild(first);
-    } else if (last.getBoundingClientRect().left > vpRect.right) {
-      x -= last.getBoundingClientRect().width + gap;
-      track.prepend(last);
-    }
+  const LOOP_W = track.scrollWidth;
+  let total = track.scrollWidth;
+  while (total < viewport.clientWidth * 3) {
+    originals.forEach(node => track.appendChild(node.cloneNode(true)));
+    total = track.scrollWidth;
   }
 
-  let prev = performance.now();
-  function loop(t){
-    const dt = Math.min(0.05, (t - prev) / 1000);
-    prev = t;
-    const v = base + boost;
-    x -= v * dt;
-    const step = 1 / Math.max(1, window.devicePixelRatio);
-    const snapped = Math.round(x / step) * step;
-    track.style.transform = `translate3d(${snapped}px,0,0)`;
-    recycle();
-    if (!down) boost *= 0.9;      // decay when not dragging
+  // prevent native dragging/select glitches
+  track.querySelectorAll('a, img').forEach(el => el.setAttribute('draggable','false'));
+
+  // start in middle copy
+  viewport.scrollLeft = LOOP_W;
+
+  const BASE = reduce ? 0 : 40; // px/sec
+  let boost = 0;
+  let down = false;
+  let dragStart = 0;
+  let lastX = 0;
+  let lastPT = 0; // last pointer time
+  let dragging = false;
+  const THRESH = 6;
+  let lastFrame = performance.now();
+
+  function loop(now) {
+    const dt = Math.min(0.05, (now - lastFrame) / 1000);
+    lastFrame = now;
+    let next = viewport.scrollLeft + (BASE + boost) * dt;
+
+    // keep scroll in middle set
+    if (next >= LOOP_W * 1.5) next -= LOOP_W;
+    else if (next <= LOOP_W * 0.5) next += LOOP_W;
+
+    viewport.scrollLeft = Math.round(next);
+    if (!down) boost *= 0.9;
     requestAnimationFrame(loop);
   }
   requestAnimationFrame(loop);
 
-  // Only when pointer is **down** do we change speed
-  track.addEventListener('pointerdown', (e) => {
-    down = true; dragging = false; lastX = e.clientX; lastT = performance.now();
-    track.setPointerCapture(e.pointerId);
+  viewport.addEventListener('pointerdown', e => {
+    down = true;
+    dragging = false;
+    dragStart = lastX = e.clientX;
+    lastPT = performance.now();
+    viewport.setPointerCapture(e.pointerId);
     track.classList.add('grabbing');
   });
 
-  track.addEventListener('pointermove', (e) => {
-    if (!down) return;                 // hovering does nothing
+  viewport.addEventListener('pointermove', (e) => {
+    if (!down) return;
     const now = performance.now();
     const dx = e.clientX - lastX;
-    const dt = Math.max(1, now - lastT); // ms
-    if (!dragging && Math.abs(dx) > THRESH) dragging = true;
-    if (dragging){
-      // instantaneous px/ms -> px/sec; amplify nonlinearly for "exponential" feel
-      const vel = (dx / dt) * 1000;
+    if (!dragging && Math.abs(e.clientX - dragStart) > THRESH) dragging = true;
+    if (dragging) {
+      const dt = Math.max(1, now - lastPT);
+      const vel = (dx / dt) * 1000; // px/sec
       const sign = Math.sign(vel);
-      const mag = Math.min(MAX, Math.pow(Math.abs(vel) * 250, 1.15));
-      boost = -sign * mag;            // negative = move left
-      lastX = e.clientX; lastT = now;
+      const mag = Math.pow(Math.abs(vel) * 300, 1.1);
+      boost = -sign * Math.min(2000, mag);
+      lastX = e.clientX;
+      lastPT = now;
       e.preventDefault();
     }
   }, { passive:false });
 
-  function endDrag(e){
+  const end = (e) => {
     if (!down) return;
     down = false;
-    track.releasePointerCapture?.(e.pointerId);
+    viewport.releasePointerCapture?.(e.pointerId);
     track.classList.remove('grabbing');
-  }
-  track.addEventListener('pointerup', endDrag);
-  track.addEventListener('pointercancel', endDrag);
-
-  // Arrow buttons give a nudge
-  const nudge = dir => { boost = dir * 500; setTimeout(()=> boost = 0, 180); };
-  leftBtn?.addEventListener('click', ()=> nudge(+1));   // view left
-  rightBtn?.addEventListener('click', ()=> nudge(-1));  // view right
+  };
+  viewport.addEventListener('pointerup', end);
+  viewport.addEventListener('pointercancel', end);
 })();

--- a/assets/js/heroPattern.js
+++ b/assets/js/heroPattern.js
@@ -18,7 +18,7 @@ if (hero) {
     const w = canvas.width;
     const h = canvas.height;
     ctx.clearRect(0, 0, w, h);
-    ctx.strokeStyle = 'rgba(31,111,74,0.4)';
+    ctx.strokeStyle = 'rgba(31,111,74,0.35)';
     ctx.lineWidth = 1;
     const grid = 40;
     for (let x = (-offset % grid); x < w; x += grid) {
@@ -35,7 +35,7 @@ if (hero) {
     }
   }
   function loop() {
-    offset += 0.3;
+    offset += 0.2;
     draw();
     requestAnimationFrame(loop);
   }

--- a/index.html
+++ b/index.html
@@ -68,45 +68,65 @@
             <h2>Projects</h2>
           </div>
           <div class="carousel" id="project-carousel">
-            <button class="car-arrow left" aria-label="Scroll left">←</button>
-
             <div class="carousel-viewport">
               <div class="carousel-track">
-                    <a
-                      class="project-card"
-                      href="https://example.com/sales-insights"
-                      target="_blank"
-                      rel="noopener"
-                    >
-                      <h3>Sales Insights <span class="ext" aria-hidden="true">↗</span></h3>
-                      <p>
-                        Interactive Power BI dashboard for cohort retention and product
-                        trends.
-                      </p>
-                    </a>
-                    <a
-                      class="project-card"
-                      href="https://example.com/excel-automation"
-                      target="_blank"
-                      rel="noopener"
-                    >
-                      <h3>Excel Automation <span class="ext" aria-hidden="true">↗</span></h3>
-                      <p>Automated monthly reporting using VBA and Python.</p>
-                    </a>
-                    <a
-                      class="project-card"
-                      href="https://example.com/sigma-nu"
-                      target="_blank"
-                      rel="noopener"
-                    >
-                      <h3>Sigma Nu Site <span class="ext" aria-hidden="true">↗</span></h3>
-                      <p>Modern chapter website with events and gallery.</p>
-                    </a>
-                  </div>
-                </div>
+                <a
+                  class="project-card"
+                  href="YOUR_URL_HERE"
+                  target="_blank"
+                  rel="noopener"
+                  draggable="false"
+                >
+                  <h3>NBA Power BI Dashboard <span class="ext" aria-hidden="true">↗</span></h3>
+                  <p>League trends explored in a dynamic Power BI report.</p>
+                </a>
 
-                <button class="car-arrow right" aria-label="Scroll right">→</button>
+                <a
+                  class="project-card"
+                  href="YOUR_URL_HERE"
+                  target="_blank"
+                  rel="noopener"
+                  draggable="false"
+                >
+                  <h3>E-Commerce Sales Analysis (SQL) <span class="ext" aria-hidden="true">↗</span></h3>
+                  <p>Querying orders to uncover revenue drivers.</p>
+                </a>
+
+                <a
+                  class="project-card"
+                  href="YOUR_URL_HERE"
+                  target="_blank"
+                  rel="noopener"
+                  draggable="false"
+                >
+                  <h3>Marketing Campaign Performance Dashboard (Excel) <span class="ext" aria-hidden="true">↗</span></h3>
+                  <p>Excel dashboard tracking conversion lift and ROI.</p>
+                </a>
+
+                <a
+                  class="project-card"
+                  href="YOUR_URL_HERE"
+                  target="_blank"
+                  rel="noopener"
+                  draggable="false"
+                >
+                  <h3>NeersUpdate — Co-Owner & Content Creator <span class="ext" aria-hidden="true">↗</span></h3>
+                  <p>News brand delivering concise tech and world updates.</p>
+                </a>
+
+                <a
+                  class="project-card"
+                  href="YOUR_URL_HERE"
+                  target="_blank"
+                  rel="noopener"
+                  draggable="false"
+                >
+                  <h3>App State Sigma Nu Website Design (Web Development) <span class="ext" aria-hidden="true">↗</span></h3>
+                  <p>Responsive chapter site highlighting events and members.</p>
+                </a>
               </div>
+            </div>
+          </div>
         </section>
 
         <section id="skills" class="skills reveal">


### PR DESCRIPTION
## Summary
- Rebuild projects carousel using scrollLeft loop with drag-to-speed and integer snapping
- Replace project section with five fixed-width cards and remove arrow UI
- Inject subtle animated grid background in hero that respects reduced motion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c211d42e4832c98a4125c47437acc