### PR TITLE
Refine font styles and project card layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -27,6 +27,7 @@ body {
   margin: 0;
   padding: 0;
   font-family: "Inter", sans-serif;
+  font-weight: 400;
   background: var(--bg);
   color: var(--text);
   -webkit-font-smoothing: antialiased;
@@ -41,7 +42,9 @@ img {
 }
 
 h2 {
-  color: var(--green-forest);
+  font-family: "Montserrat", sans-serif;
+  font-weight: 600;
+  color: #fff;
 }
 .container {
   width: min(1100px, 90%);
@@ -92,6 +95,8 @@ section{ scroll-margin-top: 72px; }
     z-index: 1;
   }
   .hero h1 {
+    font-family: "Montserrat", sans-serif;
+    font-weight: 800;
     font-size: clamp(2.5rem, 8vw, 5rem);
     margin: 0;
   }
@@ -322,8 +327,7 @@ section{ scroll-margin-top: 72px; }
   flex-direction: column;
   justify-content: center;
   text-align: center;
-  height: 100%;
-  aspect-ratio: 1 / 1;
+  aspect-ratio: 4 / 3;
 }
 
 .project-card h3 {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400&family=Montserrat:wght@600;800&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="assets/css/styles.css" />


### PR DESCRIPTION
## Summary
- Load Montserrat and Inter fonts and apply Montserrat ExtraBold to the hero name, Montserrat SemiBold to section headers, and Inter Regular for body text.
- Return section header colors to white for improved contrast.
- Adjust project cards to a shorter aspect ratio for a more compact grid.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a74f5471b8832e9bb88a01d1614fe9